### PR TITLE
Fix packaging to support uvx installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/DEmodoriGatsuO/sharepoint-mcp",
     packages=find_packages(),
+    py_modules=['server'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary

This PR fixes a packaging issue that prevents installation via `uvx` or `pip` from Git.

## Problem

The current `setup.py` defines a console script entry point:
```python
entry_points={
    "console_scripts": [
        "sharepoint-mcp=server:main",
    ],
},
```

However, the `server.py` file at the repository root is not properly packaged, causing:
```
ModuleNotFoundError: No module named 'server'
```

## Solution

Add `py_modules=['server']` to `setup.py` to explicitly include the root-level `server.py` file in the package.

## Changes

```diff
     packages=find_packages(),
+    py_modules=['server'],
     classifiers=[
```

This is a **one-line change** that enables proper module resolution.

## Testing

After this change, the package can be installed and run via:

```bash
# Install via uvx
uvx --from git+https://github.com/DEmodoriGatsuO/sharepoint-mcp sharepoint-mcp

# Or via pip
pip install git+https://github.com/DEmodoriGatsuO/sharepoint-mcp
sharepoint-mcp --help
```

Verified that the server starts successfully and can handle MCP protocol requests.

## Benefits

✅ Enables installation via `uvx` for easy testing and deployment
✅ Makes the package pip-installable from Git
✅ No breaking changes to existing functionality
✅ Minimal, focused fix

## References

- [setuptools py_modules documentation](https://setuptools.pypa.io/en/latest/references/keywords.html#py-modules)
- Related to using this server with [luthersystems/connectorhub](https://github.com/luthersystems/connectorhub)