### PR TITLE
feat: add list read tools, fix upload_document base64, clean requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp>=0.1.0
+mcp[cli]>=1.9.0
 msal>=1.20.0
 requests>=2.28.0
 pandas>=1.5.0
@@ -6,5 +6,4 @@ python-docx>=0.8.11
 PyPDF2>=3.0.0
 openpyxl>=3.1.0
 python-dotenv>=0.21.0
-mcp[cli]
 uvicorn>=0.20.0

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -281,6 +281,74 @@ async def test_update_list_item(mock_patch, graph_client):
     assert "Graph API error: 403" in str(excinfo.value)
 
 
+@patch("requests.get")
+async def test_get_lists(mock_get, graph_client):
+    """Test get_lists returns all lists for a site."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "value": [
+            {
+                "id": "list1",
+                "displayName": "Tasks",
+                "list": {"template": "genericList"},
+            },
+            {
+                "id": "list2",
+                "displayName": "Documents",
+                "list": {"template": "documentLibrary"},
+            },
+        ]
+    }
+    mock_get.return_value = mock_response
+
+    result = await graph_client.get_lists("site1")
+    assert len(result["value"]) == 2
+    assert result["value"][0]["displayName"] == "Tasks"
+    call_url = mock_get.call_args[0][0]
+    assert "sites/site1/lists" in call_url
+
+
+@patch("requests.get")
+async def test_get_list_items(mock_get, graph_client):
+    """Test get_list_items fetches items with fields expanded."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "value": [
+            {"id": "1", "fields": {"Title": "Item A", "Status": "Active"}},
+            {"id": "2", "fields": {"Title": "Item B", "Status": "Done"}},
+        ]
+    }
+    mock_get.return_value = mock_response
+
+    result = await graph_client.get_list_items("site1", "list1")
+    assert len(result["value"]) == 2
+    assert result["value"][0]["fields"]["Title"] == "Item A"
+    call_url = mock_get.call_args[0][0]
+    assert "sites/site1/lists/list1/items" in call_url
+    assert "$expand=fields" in call_url
+    assert "$top=100" in call_url
+
+
+@patch("requests.get")
+async def test_get_list_items_with_filter(mock_get, graph_client):
+    """Test get_list_items applies OData filter when provided."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "value": [{"id": "1", "fields": {"Title": "Item A", "Status": "Active"}}]
+    }
+    mock_get.return_value = mock_response
+
+    result = await graph_client.get_list_items(
+        "site1", "list1", filter_query="fields/Status eq 'Active'"
+    )
+    assert len(result["value"]) == 1
+    call_url = mock_get.call_args[0][0]
+    assert "$filter=" in call_url
+
+
 @patch("requests.post")
 async def test_create_site(mock_post, graph_client):
     """Test create_site sends POST with correct display name and alias."""

--- a/tools/read_tools.py
+++ b/tools/read_tools.py
@@ -1,5 +1,6 @@
 """SharePoint read-only tools."""
 
+import base64
 import json
 import logging
 
@@ -294,4 +295,130 @@ def register_read_tools(mcp: FastMCP):
             return json.dumps(result, indent=2)
         except Exception as e:
             logger.error(f"Error in get_item_metadata: {str(e)}")
+            raise
+
+    @mcp.tool()
+    async def download_file(
+        ctx: Context, site_id: str, drive_id: str, item_id: str, filename: str
+    ) -> str:
+        """Download a file from SharePoint and return its content as base64.
+
+        Use this to retrieve binary files (docx, xlsx, pdf, etc.) so they can
+        be edited and re-uploaded. Pair with upload_document to complete edits.
+
+        Args:
+            site_id: ID of the site
+            drive_id: ID of the document library
+            item_id: ID of the file
+            filename: Name of the file (used for logging)
+        """
+        logger.info(f"Tool called: download_file for file: {filename}")
+        try:
+            sp_ctx = ctx.request_context.lifespan_context
+            _check_auth(sp_ctx)
+            await refresh_token_if_needed(sp_ctx)
+            graph_client = GraphClient(sp_ctx)
+
+            content = await graph_client.get_document_content(
+                site_id, drive_id, item_id
+            )
+            encoded = base64.b64encode(content).decode("utf-8")
+            logger.info(
+                f"Successfully downloaded file: {filename} ({len(content)} bytes)"
+            )
+            return json.dumps(
+                {
+                    "filename": filename,
+                    "size_bytes": len(content),
+                    "content_base64": encoded,
+                },
+                indent=2,
+            )
+        except Exception as e:
+            logger.error(f"Error in download_file: {str(e)}")
+            raise
+
+    @mcp.tool()
+    async def get_lists(ctx: Context, site_id: str) -> str:
+        """List all SharePoint lists (and document libraries) in a site.
+
+        Returns list names, IDs, and templates so you can query items.
+        For subsites, use the compound site ID format: siteCollectionId,webId
+
+        Args:
+            site_id: The site ID. For subsites use compound format
+                (e.g. "f474e3b9-...,0b580fc8-...")
+        """
+        logger.info(f"Tool called: get_lists for site: {site_id}")
+        try:
+            sp_ctx = ctx.request_context.lifespan_context
+            _check_auth(sp_ctx)
+            await refresh_token_if_needed(sp_ctx)
+            graph_client = GraphClient(sp_ctx)
+
+            result = await graph_client.get_lists(site_id)
+            lists = result.get("value", [])
+            formatted = [
+                {
+                    "id": lst.get("id", "Unknown"),
+                    "name": lst.get("displayName", "Unknown"),
+                    "description": lst.get("description", ""),
+                    "web_url": lst.get("webUrl", "Unknown"),
+                    "template": lst.get("list", {}).get("template", "Unknown"),
+                    "created": lst.get("createdDateTime", "Unknown"),
+                    "last_modified": lst.get("lastModifiedDateTime", "Unknown"),
+                }
+                for lst in lists
+            ]
+            logger.info(f"Successfully retrieved {len(formatted)} lists")
+            return json.dumps(formatted, indent=2)
+        except Exception as e:
+            logger.error(f"Error in get_lists: {str(e)}")
+            raise
+
+    @mcp.tool()
+    async def get_list_items(
+        ctx: Context,
+        site_id: str,
+        list_id: str,
+        top: int = 100,
+        filter_query: str = "",
+    ) -> str:
+        """Get items from a SharePoint list with all their column/field values.
+
+        This queries the Graph API /sites/{siteId}/lists/{listId}/items endpoint
+        with $expand=fields to return all column values including Status, Title, etc.
+
+        Args:
+            site_id: The site ID. For subsites use compound format
+                (e.g. "f474e3b9-...,0b580fc8-...")
+            list_id: The list ID (GUID) or display name
+            top: Maximum items to return (default 100, max 5000)
+            filter_query: Optional OData filter (e.g. "fields/Status eq 'Active'")
+        """
+        logger.info(f"Tool called: get_list_items for list: {list_id}")
+        try:
+            sp_ctx = ctx.request_context.lifespan_context
+            _check_auth(sp_ctx)
+            await refresh_token_if_needed(sp_ctx)
+            graph_client = GraphClient(sp_ctx)
+
+            result = await graph_client.get_list_items(
+                site_id, list_id, top=top, filter_query=filter_query
+            )
+            items = result.get("value", [])
+            formatted = [
+                {
+                    "id": item.get("id", "Unknown"),
+                    "web_url": item.get("webUrl", ""),
+                    "created": item.get("createdDateTime", ""),
+                    "last_modified": item.get("lastModifiedDateTime", ""),
+                    "fields": item.get("fields", {}),
+                }
+                for item in items
+            ]
+            logger.info(f"Successfully retrieved {len(formatted)} list items")
+            return json.dumps(formatted, indent=2)
+        except Exception as e:
+            logger.error(f"Error in get_list_items: {str(e)}")
             raise

--- a/tools/write_tools.py
+++ b/tools/write_tools.py
@@ -1,5 +1,6 @@
 """SharePoint write tools (CRUD on existing structures)."""
 
+import base64
 import json
 import logging
 from typing import Dict, Any
@@ -23,7 +24,7 @@ def register_write_tools(mcp: FastMCP):
         drive_id: str,
         folder_path: str,
         file_name: str,
-        file_content: bytes,
+        file_content: str,
         content_type: str = None,
     ) -> str:
         """Upload a document to a SharePoint document library.
@@ -33,7 +34,8 @@ def register_write_tools(mcp: FastMCP):
             drive_id: ID of the document library
             folder_path: Path to the folder (e.g. "General" or "Documents/Folder1")
             file_name: Name of the file to create
-            file_content: Content of the file as bytes
+            file_content: Base64-encoded file content. Use the content_base64 field
+                returned by download_file directly.
             content_type: MIME type of the file
 
         Returns:
@@ -46,8 +48,13 @@ def register_write_tools(mcp: FastMCP):
             await refresh_token_if_needed(sp_ctx)
             graph_client = GraphClient(sp_ctx)
 
+            try:
+                file_bytes = base64.b64decode(file_content)
+            except Exception as e:
+                raise ValueError(f"file_content must be valid base64-encoded data: {e}")
+
             doc_info = await graph_client.upload_document(
-                site_id, drive_id, folder_path, file_name, file_content, content_type
+                site_id, drive_id, folder_path, file_name, file_bytes, content_type
             )
             logger.info(f"Successfully uploaded document: {file_name}")
             return json.dumps(doc_info, indent=2)

--- a/utils/_graph_list_ops.py
+++ b/utils/_graph_list_ops.py
@@ -9,6 +9,46 @@ logger = logging.getLogger("graph_client")
 class _GraphListOpsMixin:
     """List CRUD and schema operations for the Microsoft Graph API."""
 
+    async def get_lists(self, site_id: str) -> Dict[str, Any]:
+        """Get all lists in a SharePoint site."""
+        endpoint = f"sites/{site_id}/lists"
+        logger.info(f"Getting lists for site: {site_id}")
+        return await self.get(endpoint)
+
+    async def get_list_items(
+        self,
+        site_id: str,
+        list_id: str,
+        top: int = 100,
+        select_fields: List[str] | None = None,
+        filter_query: str = "",
+        expand_fields: bool = True,
+    ) -> Dict[str, Any]:
+        """Get items from a SharePoint list with their field values.
+
+        Args:
+            site_id: The site ID (can be compound: siteCollectionId,webId).
+            list_id: The list ID or list display name.
+            top: Maximum number of items to return (default 100).
+            select_fields: Optional list of field names to select.
+            filter_query: Optional OData $filter expression.
+            expand_fields: Whether to expand fields (default True).
+        """
+        endpoint = f"sites/{site_id}/lists/{list_id}/items"
+        params = [f"$top={top}"]
+        if expand_fields:
+            if select_fields:
+                fields_select = ",".join(select_fields)
+                params.append(f"$expand=fields($select={fields_select})")
+            else:
+                params.append("$expand=fields")
+        if filter_query:
+            params.append(f"$filter={filter_query}")
+        if params:
+            endpoint += "?" + "&".join(params)
+        logger.info(f"Getting list items from list: {list_id} in site: {site_id}")
+        return await self.get(endpoint)
+
     async def create_list(
         self,
         site_id: str,


### PR DESCRIPTION
## Summary

This PR addresses all open issues and incorporates changes from pending PRs.

### Changes

- **Closes #16** — Add `get_lists` and `get_list_items` MCP tools for reading SharePoint lists
- **Incorporates #14** — Fix `upload_document` to accept base64-encoded `str` instead of raw `bytes` (MCP/JSON cannot serialize binary); add `download_file` tool for round-trip edit workflows
- **Incorporates #15** — List read tools from that branch (Azure CI/CD workflow excluded as it is environment-specific)
- **Already applied #4** — `setup.py` already contained `py_modules=["server"]`
- **Already applied #3** — MseeP badge already present in README

### New tools

| Tool | Description |
|------|-------------|
| `get_lists` | Returns all lists in a site (id, name, template, web_url) |
| `get_list_items` | Returns list items with all field values; supports OData `filter_query` |
| `download_file` | Downloads a file as base64 for editing and re-uploading |

### Fix

`upload_document` now accepts `file_content: str` (base64) instead of `bytes`. Use the `content_base64` field returned by `download_file` directly.

## Test plan

- [x] 18 unit tests pass (`pytest`)
- [x] `black .` clean
- [x] `ruff check .` clean
- [x] New tests: `test_get_lists`, `test_get_list_items`, `test_get_list_items_with_filter`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)